### PR TITLE
Fix: ajuste novedad postcontractuales

### DIFF
--- a/controllers/preliquidacionct.go
+++ b/controllers/preliquidacionct.go
@@ -49,10 +49,8 @@ func liquidarCPS(contrato models.Contrato) {
 		fmt.Println("ano:", anoIterativo)
 		reglasNuevas = ""
 		query := "Ano:" + strconv.Itoa(anoIterativo) + ",Mes:" + strconv.Itoa(mesIterativo) + ",Nominaid:414"
-		fmt.Println(beego.AppConfig.String("UrlTitanCrud") + "/preliquidacion?limit=-1&query=" + query)
 		if err := request.GetJson(beego.AppConfig.String("UrlTitanCrud")+"/preliquidacion?limit=-1&query="+query, &aux); err == nil {
 			LimpiezaRespuestaRefactor(aux, &preliquidacion)
-			fmt.Println(preliquidacion[0])
 			if preliquidacion[0].Id == 0 {
 				preliquidacion[0] = registrarPreliquidacion(anoIterativo, mesIterativo, 476, 414)
 				contratoPreliquidacion = registrarContratoPreliquidacion(preliquidacion[0].Id, contrato.Id, contratoPreliquidacion)

--- a/models/otro_si.go
+++ b/models/otro_si.go
@@ -5,5 +5,6 @@ import "time"
 type OtroSi struct {
 	NumeroContrato string
 	Vigencia       int
+	Documento      string
 	FechaFin       time.Time
 }

--- a/models/sucesor.go
+++ b/models/sucesor.go
@@ -3,9 +3,10 @@ package models
 import "time"
 
 type Sucesor struct {
-	NumeroContrato string
-	Vigencia       int
-	Documento      string
-	NombreCompleto string
-	FechaInicio    time.Time
+	NumeroContrato  string
+	Vigencia        int
+	DocumentoNuevo  string
+	NombreCompleto  string
+	DocumentoActual string
+	FechaInicio     time.Time
 }

--- a/models/suspension.go
+++ b/models/suspension.go
@@ -5,6 +5,7 @@ import "time"
 type Suspension struct {
 	NumeroContrato string
 	Vigencia       int
+	Documento      string
 	FechaInicio    time.Time
 	FechaFin       time.Time
 }

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -163,7 +163,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/titan_api_mid/controllers:NovedadController"] = append(beego.GlobalControllerRouter["github.com/udistrital/titan_api_mid/controllers:NovedadController"],
         beego.ControllerComments{
             Method: "CancelarContrato",
-            Router: "/cancelar_contrato/:NumeroContrato/:Vigencia",
+            Router: "/cancelar_contrato/:NumeroContrato/:Vigencia/:Documento",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -482,7 +482,7 @@
                 }
             }
         },
-        "/novedad/cancelar_contrato/{NumeroContrato}/{Vigencia}": {
+        "/novedad/cancelar_contrato/{NumeroContrato}/{Vigencia}/{Documento}": {
             "get": {
                 "tags": [
                     "novedad"
@@ -502,6 +502,14 @@
                         "in": "path",
                         "name": "Vigencia",
                         "description": "Vigencia del contrato que se va a cancelar",
+                        "schema": {
+                            "$ref": "#/definitions/true"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "Documento",
+                        "description": "Documento del contratista",
                         "schema": {
                             "$ref": "#/definitions/true"
                         }
@@ -589,7 +597,7 @@
                     {
                         "in": "body",
                         "name": "OtroSí",
-                        "description": "Nueva Fecha de finalización del contrato",
+                        "description": "Documentos de contratista Nueva Fecha de finalización del contrato",
                         "required": true,
                         "schema": {
                             "$ref": "#/definitions/models.OtroSi"
@@ -1159,6 +1167,9 @@
             "title": "OtroSi",
             "type": "object",
             "properties": {
+                "Documento": {
+                    "type": "string"
+                },
                 "FechaFin": {
                     "type": "string",
                     "format": "datetime"
@@ -1281,7 +1292,10 @@
             "title": "Sucesor",
             "type": "object",
             "properties": {
-                "Documento": {
+                "DocumentoActual": {
+                    "type": "string"
+                },
+                "DocumentoNuevo": {
                     "type": "string"
                 },
                 "FechaInicio": {
@@ -1304,6 +1318,9 @@
             "title": "Suspension",
             "type": "object",
             "properties": {
+                "Documento": {
+                    "type": "string"
+                },
                 "FechaFin": {
                     "type": "string",
                     "format": "datetime"

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -320,7 +320,7 @@ paths:
             $ref: '#/definitions/models.Novedad'
         "403":
           description: body is empty
-  /novedad/cancelar_contrato/{NumeroContrato}/{Vigencia}:
+  /novedad/cancelar_contrato/{NumeroContrato}/{Vigencia}/{Documento}:
     get:
       tags:
       - novedad
@@ -335,6 +335,11 @@ paths:
       - in: path
         name: Vigencia
         description: Vigencia del contrato que se va a cancelar
+        schema:
+          $ref: '#/definitions/true'
+      - in: path
+        name: Documento
+        description: Documento del contratista
         schema:
           $ref: '#/definitions/true'
       responses:
@@ -390,7 +395,7 @@ paths:
       parameters:
       - in: body
         name: OtroSí
-        description: Nueva Fecha de finalización del contrato
+        description: Documentos de contratista Nueva Fecha de finalización del contrato
         required: true
         schema:
           $ref: '#/definitions/models.OtroSi'
@@ -784,6 +789,8 @@ definitions:
     title: OtroSi
     type: object
     properties:
+      Documento:
+        type: string
       FechaFin:
         type: string
         format: datetime
@@ -870,7 +877,9 @@ definitions:
     title: Sucesor
     type: object
     properties:
-      Documento:
+      DocumentoActual:
+        type: string
+      DocumentoNuevo:
         type: string
       FechaInicio:
         type: string
@@ -886,6 +895,8 @@ definitions:
     title: Suspension
     type: object
     properties:
+      Documento:
+        type: string
       FechaFin:
         type: string
         format: datetime


### PR DESCRIPTION
Se han ajustado los métodos de las novedades contractuales para que sean posbles n sesiones, además de ajustar el otro sí e caso de que el contrato haya tenido una sesión previamente