### PR TITLE
fix: ajuste de cálculo de ibc

### DIFF
--- a/controllers/preliquidacionhch.go
+++ b/controllers/preliquidacionhch.go
@@ -47,7 +47,11 @@ func liquidarHCH(contrato models.Contrato, general bool) {
 
 	semanasContrato := int(calcularSemanasContratoDVE(contrato.FechaInicio, contrato.FechaFin))
 	fmt.Println("SemanasContrato: ", semanasContrato)
-
+	if general {
+		predicados = append(predicados, models.Predicado{Nombre: "general(1)."})
+	} else {
+		predicados = append(predicados, models.Predicado{Nombre: "general(0)."})
+	}
 	predicados = append(predicados, models.Predicado{Nombre: "valor_contrato(" + contrato.Documento + "," + fmt.Sprintf("%f", contrato.ValorContrato) + "). "})
 	predicados = append(predicados, models.Predicado{Nombre: "duracion_contrato(" + contrato.Documento + "," + strconv.Itoa(semanasContrato) + "," + strconv.Itoa(contrato.Vigencia) + "). "})
 	reglasbase := cargarReglasBase("HCH") + reglasAlivios + FormatoReglas(predicados)

--- a/controllers/preliquidacionhcs.go
+++ b/controllers/preliquidacionhcs.go
@@ -48,7 +48,11 @@ func liquidarHCS(contrato models.Contrato, general bool) {
 
 	semanasContrato := int(calcularSemanasContratoDVE(contrato.FechaInicio, contrato.FechaFin))
 	fmt.Println("SemanasContrato: ", semanasContrato)
-
+	if general {
+		predicados = append(predicados, models.Predicado{Nombre: "general(1)."})
+	} else {
+		predicados = append(predicados, models.Predicado{Nombre: "general(0)."})
+	}
 	predicados = append(predicados, models.Predicado{Nombre: "valor_contrato(" + contrato.Documento + "," + fmt.Sprintf("%f", contrato.ValorContrato) + "). "})
 	predicados = append(predicados, models.Predicado{Nombre: "duracion_contrato(" + contrato.Documento + "," + strconv.Itoa(semanasContrato) + "," + strconv.Itoa(contrato.Vigencia) + "). "})
 	reglasbase := cargarReglasBase("HCS") + reglasAlivios + FormatoReglas(predicados)


### PR DESCRIPTION
Se ajusta para en caso de no ser el contrato general o totalizado no se tenga en cuenta el hecho de que el salario mínimo es el mínimo valor que puede tomar el ibc, esto con el fin de ajustar la nómina