### PR TITLE
Fix: ajuste de cálculo del ibc

### DIFF
--- a/controllers/preliquidacionhch.go
+++ b/controllers/preliquidacionhch.go
@@ -104,7 +104,7 @@ func liquidarHCH(contrato models.Contrato, general bool) {
 					if mes == int(contrato.FechaFin.Month()) && ano == contrato.FechaFin.Year() {
 						break
 					}
-					query := "ContratoPreliquidacionId.PreliquidacionId.Ano:" + strconv.Itoa(ano) + ",ContratoPreliquidacionId.PreliquidacionId.Mes:" + strconv.Itoa(mes) + ",ContratoPreliquidacionId.ContratoId.NumeroContrato:" + contrato.NumeroContrato + ",ContratoPreliquidacionId.ContratoId.Vigencia:" + strconv.Itoa(contrato.Vigencia)
+					query := "ContratoPreliquidacionId.PreliquidacionId.Ano:" + strconv.Itoa(ano) + ",ContratoPreliquidacionId.PreliquidacionId.Mes:" + strconv.Itoa(mes) + ",ContratoPreliquidacionId.ContratoId.NumeroContrato:" + contrato.NumeroContrato + ",ContratoPreliquidacionId.ContratoId.Vigencia:" + strconv.Itoa(contrato.Vigencia) + ",ContratoPreliquidacionId.ContratoId.DependenciaId:" + strconv.Itoa(contrato.DependenciaId) + ",ContratoPreliquidacionId.ContratoId.Documento:" + contrato.Documento
 					fmt.Println(beego.AppConfig.String("UrlTitanCrud") + "/detalle_preliquidacion?limit=-1&query=" + query)
 					if err := request.GetJson(beego.AppConfig.String("UrlTitanCrud")+"/detalle_preliquidacion?limit=-1&query="+query, &aux); err == nil {
 						fmt.Println()

--- a/controllers/preliquidacionhch.go
+++ b/controllers/preliquidacionhch.go
@@ -47,7 +47,11 @@ func liquidarHCH(contrato models.Contrato, general bool) {
 
 	semanasContrato := int(calcularSemanasContratoDVE(contrato.FechaInicio, contrato.FechaFin))
 	fmt.Println("SemanasContrato: ", semanasContrato)
-
+	if general {
+		predicados = append(predicados, models.Predicado{Nombre: "general(1)."})
+	} else {
+		predicados = append(predicados, models.Predicado{Nombre: "general(0)."})
+	}
 	predicados = append(predicados, models.Predicado{Nombre: "valor_contrato(" + contrato.Documento + "," + fmt.Sprintf("%f", contrato.ValorContrato) + "). "})
 	predicados = append(predicados, models.Predicado{Nombre: "duracion_contrato(" + contrato.Documento + "," + strconv.Itoa(semanasContrato) + "," + strconv.Itoa(contrato.Vigencia) + "). "})
 	reglasbase := cargarReglasBase("HCH") + reglasAlivios + FormatoReglas(predicados)

--- a/controllers/preliquidacionhcs.go
+++ b/controllers/preliquidacionhcs.go
@@ -48,7 +48,11 @@ func liquidarHCS(contrato models.Contrato, general bool) {
 
 	semanasContrato := int(calcularSemanasContratoDVE(contrato.FechaInicio, contrato.FechaFin))
 	fmt.Println("SemanasContrato: ", semanasContrato)
-
+	if general {
+		predicados = append(predicados, models.Predicado{Nombre: "general(1)."})
+	} else {
+		predicados = append(predicados, models.Predicado{Nombre: "general(0)."})
+	}
 	predicados = append(predicados, models.Predicado{Nombre: "valor_contrato(" + contrato.Documento + "," + fmt.Sprintf("%f", contrato.ValorContrato) + "). "})
 	predicados = append(predicados, models.Predicado{Nombre: "duracion_contrato(" + contrato.Documento + "," + strconv.Itoa(semanasContrato) + "," + strconv.Itoa(contrato.Vigencia) + "). "})
 	reglasbase := cargarReglasBase("HCS") + reglasAlivios + FormatoReglas(predicados)

--- a/controllers/preliquidacionhcs.go
+++ b/controllers/preliquidacionhcs.go
@@ -106,7 +106,7 @@ func liquidarHCS(contrato models.Contrato, general bool) {
 					if mes == int(contrato.FechaFin.Month()) && ano == contrato.FechaFin.Year() {
 						break
 					}
-					query := "ContratoPreliquidacionId.PreliquidacionId.Ano:" + strconv.Itoa(ano) + ",ContratoPreliquidacionId.PreliquidacionId.Mes:" + strconv.Itoa(mes) + ",ContratoPreliquidacionId.ContratoId.NumeroContrato:" + contrato.NumeroContrato + ",ContratoPreliquidacionId.ContratoId.Vigencia:" + strconv.Itoa(contrato.Vigencia) + ",ContratoPreliquidacionId.ContratoId.Documento:" + contrato.Documento
+					query := "ContratoPreliquidacionId.PreliquidacionId.Ano:" + strconv.Itoa(ano) + ",ContratoPreliquidacionId.PreliquidacionId.Mes:" + strconv.Itoa(mes) + ",ContratoPreliquidacionId.ContratoId.NumeroContrato:" + contrato.NumeroContrato + ",ContratoPreliquidacionId.ContratoId.Vigencia:" + strconv.Itoa(contrato.Vigencia) + ",ContratoPreliquidacionId.ContratoId.Documento:" + contrato.Documento + ",ContratoPreliquidacionId.ContratoId.DependenciaId:" + strconv.Itoa(contrato.DependenciaId)
 					if err := request.GetJson(beego.AppConfig.String("UrlTitanCrud")+"/detalle_preliquidacion?limit=-1&query="+query, &aux); err == nil {
 						fmt.Println()
 						LimpiezaRespuestaRefactor(aux, &semanas)


### PR DESCRIPTION
Se ajusta para que en caso de no ser el contrato general o totalizado, no se tenga en cuenta que el salario mínimo es el mínimo valor que puede tomar el ibc, esto para ajustar la nómina de vinculación especial al momento de calcular los aportes a seguridad social