### PR TITLE
Fix: ajuste de desagregado HCS

### DIFF
--- a/golog/golog_desagregado.go
+++ b/golog/golog_desagregado.go
@@ -13,7 +13,6 @@ func DesagregarContrato(reglas string, categoria string, cedula string, dedicaci
 	var nombreConcepto string
 	var valorCalculado float64
 	var idConcepto int
-	fmt.Println(reglas)
 	m := NewMachine().Consult(reglas)
 	fmt.Println("desagregado(" + categoria + "," + cedula + "," + dedicacion + "," + ano + ",N,V).")
 	total := m.ProveAll("desagregado(" + categoria + "," + cedula + "," + dedicacion + "," + ano + ",N,V).")

--- a/models/datos_vinculacion.go
+++ b/models/datos_vinculacion.go
@@ -8,4 +8,5 @@ type DatosVinculacion struct {
 	Categoria      string
 	NumeroSemanas  int
 	HorasSemanales int
+	NivelAcademico string
 }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -888,6 +888,9 @@
                     "type": "integer",
                     "format": "int64"
                 },
+                "NivelAcademico": {
+                    "type": "string"
+                },
                 "NumeroContrato": {
                     "type": "string"
                 },

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -599,6 +599,8 @@ definitions:
       HorasSemanales:
         type: integer
         format: int64
+      NivelAcademico:
+        type: string
       NumeroContrato:
         type: string
       NumeroSemanas:


### PR DESCRIPTION
Ahora los contratos cuya dedicación sea HCP se evaluará si es de posgrado o pregado, y además de eso se hace un lower case de la categoría con el fin de prevención de errores en el ruler