### PR TITLE
Fix: ajuste de liquidación mes final HCS

### DIFF
--- a/models/contrato.go
+++ b/models/contrato.go
@@ -19,6 +19,7 @@ type Contrato struct {
 	Cdp               int
 	Rp                int
 	Unico             bool
+	Completo          bool
 	Activo            bool
 	FechaCreacion     string
 	FechaModificacion string

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -736,6 +736,9 @@
                     "type": "integer",
                     "format": "int64"
                 },
+                "Completo": {
+                    "type": "boolean"
+                },
                 "DependenciaId": {
                     "type": "integer",
                     "format": "int64"

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -492,6 +492,8 @@ definitions:
       Cdp:
         type: integer
         format: int64
+      Completo:
+        type: boolean
       DependenciaId:
         type: integer
         format: int64


### PR DESCRIPTION
Ahora se ajusta para que las semanas liquidadas correspondan a las semanas totales, si por ejemplo la fecha de la resolución se cumple en noviembre pero las semanas se cumplen en su totalidad en octubre, se liquidará octubre como mes final, agregando los correspondientes valores de las prestaciones.